### PR TITLE
More updates for your 2.4.2 pull request

### DIFF
--- a/resources/ntsc_to_pal_abridged_pseudo_patch.txt
+++ b/resources/ntsc_to_pal_abridged_pseudo_patch.txt
@@ -45,6 +45,7 @@ org $80CD8E
 org $80FFC0
 
 ; Country code and checksum
+; NOTE: This section is also different on Virtual Console NTSC and JU
 org $80FFD9
     db #$02,#$01,#$00,#$04,#$84,#$FB,#$7B
 
@@ -1779,6 +1780,18 @@ org $8DCA4E
     dw ...
 org $8DCAAA
 
+; Tourian red flashing
+; NOTE: This section is the same on NTSC and PAL but different on Virtual Console NTSC and JU
+org $8DF895
+    dw ...
+org $8DF941
+
+; Old Tourian escape shaft flashing
+; NOTE: This section is the same on NTSC and PAL but different on Virtual Console NTSC and JU
+org $8DFA6D
+    dw ...
+org $8DFBC1
+
 ; Freespace
 org $8DFFF1
 
@@ -2813,6 +2826,12 @@ org $A49A6C  <--  org $A49A53
 org $A49A79  <--  org $A49A60
     ADC #$0001    ; previously ADC #$0000
 
+; Crocomire palette
+; NOTE: This section is the same on NTSC and PAL but different on Virtual Console NTSC and JU
+org $A4B936  <--  org $A4B91D
+    dw ...
+org $A4B956  <--  org $A4B93D
+
 ; Crocomire instruction lists (timing differences)
 org $A4BB03  <--  org $A4BAEA
     dw ...
@@ -3166,6 +3185,18 @@ org $A7A93A  <--  org $A7A924
 ; Kraid timer
 org $A7AA7F  <--  org $A7AA69
     LDA #$00FA    ; previously LDA #$012C
+
+; Kraid background palette
+; NOTE: This section is the same on NTSC and PAL and Virtual Console NTSC but different on JU
+org $A7B3E9  <--  org $A7B3D3
+    dw ...
+org $A7B409  <--  org $A7B3F3
+
+; Kraid sprite palette
+; NOTE: This section is the same on NTSC and PAL and Virtual Console NTSC but different on JU
+org $A7B529  <--  org $A7B513
+    dw ...
+org $A7B549  <--  org $A7B533
 
 ; Kraid X position
 org $A7B671  <--  org $A7B65B
@@ -3641,6 +3672,12 @@ org $A9BB9E  <--  org $A9BB51
 ; MB2 AI velocity?
 org $A9BBC0  <--  org $A9BB73
     ADC #$01CC    ; previously ADC #$0180
+
+; MB1 phase ended room palettes
+; NOTE: This section is the same on NTSC and PAL but different on Virtual Console NTSC and JU
+org $A9D0FF  <--  org $A9D0B2
+    dw ...
+org $A9D18F  <--  org $A9D142
 
 ; Freespace
 org $A9FBBD  <--  org $A9FB70
@@ -4147,6 +4184,12 @@ org $B88000
 ; Bank CD
 ; Bank CE
 ;=======================================================
+
+; Tileset 9 Heated Norfair palette
+; NOTE: This section is the same on NTSC and PAL and Virtual Console NTSC but different on JU
+org $C2B5E4
+    dw ...
+org $C2B6BB
 
 ; Freespace
 org $CEB22D

--- a/src/crash.asm
+++ b/src/crash.asm
@@ -442,6 +442,7 @@ CrashDump:
     ; -- Detect and Draw COP/BRK --
     LDA !ram_crash_type : AND #$0003 : BEQ .drawStack_bridge
     LDA !ram_crash_type : AND #$C000 : BNE .corruptBRKCOP
+    LDA $C1 : PHA : LDA $C3 : PHA
 
     %a8()
     LDA !ram_crash_stack : STA !ram_crash_draw_value
@@ -458,6 +459,7 @@ CrashDump:
 
     LDA [$C1] : STA !ram_crash_draw_value
     LDX #$02D8 : JSR crash_draw2 ; operand
+    PLA : STA $C3 : PLA : STA $C1
     BRA .drawBRKCOPText
 
   .drawStack_bridge
@@ -727,22 +729,22 @@ CrashMemViewer:
 
   .drawUpperHalf
     %a16()
-    LDA $C1 : PHA : LDA $C3 : PHA
-    LDA !ram_crash_mem_viewer_bank : STA $C3
-    LDA !ram_crash_mem_viewer : STA $C1
-    LDA [$C1] : STA !ram_crash_draw_value
+    LDA $41 : PHA : LDA $43 : PHA
+    LDA !ram_crash_mem_viewer_bank : STA $43
+    LDA !ram_crash_mem_viewer : STA $41
+    LDA [$41] : STA !ram_crash_draw_value
     LDX #$01E8 : JSR crash_draw4
 
     LDX #$048A
     %a8()
     LDA #$00 : STA !ram_crash_stack_line_position : STA !ram_crash_loop_counter
-    LDA $C1 : AND #$F0 : STA $C1
+    LDA $41 : AND #$F0 : STA $41
 
   .drawUpperHalfNearby
     ; draw a byte
-    LDA [$C1] : STA !ram_crash_draw_value
+    LDA [$41] : STA !ram_crash_draw_value
     JSR crash_draw2
-    INC $C1
+    INC $41
 
     ; inc tilemap position
     INX #6 : LDA !ram_crash_stack_line_position : INC
@@ -761,7 +763,7 @@ CrashMemViewer:
     %a16()
 
   .doneUpperHalf
-    PLA : STA $C3 : PLA : STA $C1
+    PLA : STA $43 : PLA : STA $41
     RTS
 
 CursorPositions:

--- a/src/defines.asm
+++ b/src/defines.asm
@@ -15,7 +15,7 @@
 !ram_last_door_lag_frames = !WRAM_START+$0C
 !ram_transition_counter = !WRAM_START+$0E
 !ram_transition_flag = !WRAM_START+$10
-!ram_transition_flag_2 = !WRAM_START+$12
+!ram_last_realtime_door = !WRAM_START+$12
 
 !ram_seg_rt_frames = !WRAM_START+$14
 !ram_seg_rt_seconds = !WRAM_START+$16

--- a/src/defines.asm
+++ b/src/defines.asm
@@ -82,8 +82,12 @@
 !ram_suits_enemy_damage_check = !WRAM_START+$78
 !ram_suits_periodic_damage_check = !WRAM_START+$7A
 
-; ^ FREE SPACE ^ up to +$86
+; ^ FREE SPACE ^ up to +$7E
 
+!ram_spacetime_read_address = !WRAM_START+$80
+!ram_spacetime_read_bank = !WRAM_START+$82
+!ram_spacetime_y = !WRAM_START+$84
+!ram_spacetime_infohud = !WRAM_START+$86
 !ram_watch_left_index = !WRAM_START+$88
 !ram_watch_right_index = !WRAM_START+$8A
 !ram_watch_write_mode = !WRAM_START+$8C

--- a/src/infohud.asm
+++ b/src/infohud.asm
@@ -575,8 +575,22 @@ endif
     ; Skip door lag and segment timer when shinetune enabled
     LDA !sram_display_mode : CMP #!IH_MODE_SHINETUNE_INDEX : BEQ .end
 
-    ; Door lag
-    BRA .pick_vanilla_infohud_transition_time
+    ; Door lag / transition time
+    LDA !sram_lag_counter_mode : BNE .transition_time_full
+    LDA !ram_last_door_lag_frames
+    BRA .infohud_transition_time
+  .transition_time_full
+    LDA !ram_last_realtime_door
+  .infohud_transition_time
+    LDX #$00C2 : JSR Draw3
+    BRA .pick_segment_timer
+
+  .end
+    PLB
+    PLP
+    PLY
+    PLX
+    RTL
 
   .vanilla_infohud_draw_lag_and_reserves
     LDA !SAMUS_RESERVE_MODE : CMP #$0001 : BNE .vanilla_infohud_draw_lag
@@ -594,7 +608,6 @@ endif
     ; Skip door lag and segment timer when shinetune enabled
     LDA !sram_display_mode : CMP #!IH_MODE_SHINETUNE_INDEX : BEQ .end
 
-  .pick_vanilla_infohud_transition_time
     ; Door lag / transition time
     LDA !sram_lag_counter_mode : BNE .vanilla_infohud_transition_time_full
     LDA !ram_last_door_lag_frames
@@ -615,13 +628,6 @@ endif
     LDA #$007E : STA $02
     BRA .draw_segment_timer
 
-  .end
-    PLB
-    PLP
-    PLY
-    PLX
-    RTL
-
   .draw_segment_timer
     ; Frames
     LDA [$00] : INC $00 : INC $00 : ASL : TAX
@@ -639,7 +645,7 @@ endif
     ; Draw decimal seperators
     LDA !IH_DECIMAL : STA $7EC6B4 : STA $7EC6BA
     LDA !IH_BLANK : STA $7EC6C0
-    BRA .end
+    BRL .end
 }
 
 ih_update_hud_early:

--- a/src/infohud.asm
+++ b/src/infohud.asm
@@ -293,6 +293,7 @@ ih_after_room_transition:
     LDA !ram_transition_counter : STA !ram_last_door_lag_frames
     LDA !sram_lag_counter_mode : BEQ .done_set_door_lag
     LDA !ram_realtime_room : STA !ram_last_door_lag_frames
+    LDA !ram_realtime_room : STA !ram_last_realtime_door
   .done_set_door_lag
     LDA #$0000 : STA !ram_transition_flag
 
@@ -348,6 +349,7 @@ ih_before_room_transition:
     ; Realtime
     LDA !ram_realtime_room : STA !ram_last_realtime_room
     LDA #$0000 : STA !ram_realtime_room
+    LDA #$0000 : STA !ram_last_realtime_door
 
     ; Save temp variables
     LDA $12 : PHA

--- a/src/infohud.asm
+++ b/src/infohud.asm
@@ -572,8 +572,7 @@ endif
     LDA !sram_display_mode : CMP #!IH_MODE_SHINETUNE_INDEX : BEQ .end
 
     ; Door lag
-    LDA !ram_last_door_lag_frames : LDX #$00C2 : JSR Draw3
-    BRA .pick_segment_timer
+    BRA .vanilla_infohud_draw_door_lag
 
   .vanilla_infohud_draw_lag_and_reserves
     LDA !SAMUS_RESERVE_MODE : CMP #$0001 : BNE .vanilla_infohud_draw_lag
@@ -591,6 +590,7 @@ endif
     ; Skip door lag and segment timer when shinetune enabled
     LDA !sram_display_mode : CMP #!IH_MODE_SHINETUNE_INDEX : BEQ .end
 
+  .vanilla_infohud_draw_door_lag
     ; Door lag
     LDA !ram_last_door_lag_frames : LDX #$00C2 : JSR Draw2
 

--- a/src/infohud.asm
+++ b/src/infohud.asm
@@ -660,13 +660,7 @@ ih_update_hud_early:
     LDA !ram_gametime_room : STA !ram_last_gametime_room
     LDA !ram_realtime_room : STA !ram_last_realtime_room
 
-    ; check if we should reset segment timer
-    LDA !ram_reset_segment_later : BEQ .update_hud
-    LDA #$0000 : STA !ram_reset_segment_later
-    STA !ram_seg_rt_frames : STA !ram_seg_rt_seconds
-    STA !ram_seg_rt_minutes
-
-  .update_hud
+    ; update HUD
     LDA $12 : PHA : LDA $14 : PHA
     JSL ih_update_hud_code
     PLA : STA $14 : PLA : STA $12
@@ -1488,5 +1482,5 @@ HexToNumberGFX2:
     dw #$0C09, #$0C00, #$0C01, #$0C02, #$0C03, #$0C04, #$0C05, #$0C06, #$0C07, #$0C08
 
 print pc, " infohud bank80 end"
-warnpc $80FFC0 ; header
+warnpc $80FFB0 ; header
 

--- a/src/main.asm
+++ b/src/main.asm
@@ -11,7 +11,7 @@ lorom
 !VERSION_MINOR = 4
 !VERSION_BUILD = 2
 !VERSION_REV_1 = 0
-!VERSION_REV_2 = 0
+!VERSION_REV_2 = 1
 
 table ../resources/normal.tbl
 

--- a/src/main.asm
+++ b/src/main.asm
@@ -11,7 +11,7 @@ lorom
 !VERSION_MINOR = 4
 !VERSION_BUILD = 2
 !VERSION_REV_1 = 0
-!VERSION_REV_2 = 1
+!VERSION_REV_2 = 0
 
 table ../resources/normal.tbl
 

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -1194,8 +1194,10 @@ SpritesMenu:
     dw #sprites_show_samusproj_hitbox
     dw #sprites_show_enemyproj_hitbox
     dw #sprites_oob_viewer
+if !PRESERVE_WRAM_DURING_SPACETIME
     dw #$FFFF
     dw #sprites_spacetime_infohud
+endif
     dw #$0000
     %cm_header("SPRITE FEATURES")
 
@@ -1686,7 +1688,7 @@ ih_lag:
     %cm_numfield("Artificial Lag", !sram_artificial_lag, 0, 64, 1, 4, #0)
 
 ih_reset_seg_later:
-    %cm_jsl("Reset Segment Next Event", #.routine, #$FFFF)
+    %cm_jsl("Reset Segment Next Room", #.routine, #$FFFF)
   .routine
     TYA : STA !ram_reset_segment_later
     RTL

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -1686,7 +1686,7 @@ ih_lag:
     %cm_numfield("Artificial Lag", !sram_artificial_lag, 0, 64, 1, 4, #0)
 
 ih_reset_seg_later:
-    %cm_jsl("Reset Segment in Next Room", #.routine, #$FFFF)
+    %cm_jsl("Reset Segment Next Event", #.routine, #$FFFF)
   .routine
     TYA : STA !ram_reset_segment_later
     RTL

--- a/src/mainmenu.asm
+++ b/src/mainmenu.asm
@@ -1194,6 +1194,8 @@ SpritesMenu:
     dw #sprites_show_samusproj_hitbox
     dw #sprites_show_enemyproj_hitbox
     dw #sprites_oob_viewer
+    dw #$FFFF
+    dw #sprites_spacetime_infohud
     dw #$0000
     %cm_header("SPRITE FEATURES")
 
@@ -1216,6 +1218,7 @@ sprites_show_samusproj_hitbox:
     %cm_toggle("S Projectile Hitboxes", !ram_sprite_samusproj_hitbox_active, #1, #action_sprite_features)
 
 sprites_oob_viewer:
+{
     %cm_toggle("OOB Tile Viewer", !ram_oob_watch_active, #1, #.routine)
   .routine
     LDA !ram_oob_watch_active : BEQ .oob_off
@@ -1227,6 +1230,15 @@ sprites_oob_viewer:
     LDA #$0000 : STA !ram_sprite_features_active
     RTL
 }
+
+sprites_spacetime_infohud:
+    dw !ACTION_CHOICE
+    dl #!ram_spacetime_infohud
+    dw #$0000
+    db #$28, "Spacetime HUD ", #$FF
+    db #$28, "    VANILLA", #$FF
+    db #$28, "  PRESERVED", #$FF
+    db #$FF
 
 action_sprite_features:
 {

--- a/src/misc.asm
+++ b/src/misc.asm
@@ -197,7 +197,9 @@ org $90E874
 else
 org $90E877
 endif
-    BRA $1F
+    LDA $07F5
+    JSL $808FC1 ; queue room music track
+    BRA $18
 
 
 ; Adds frames when unpausing (nmi is turned off during vram transfers)

--- a/src/misc.asm
+++ b/src/misc.asm
@@ -504,14 +504,53 @@ spacetime_routine:
     ; Also skips out if spacetime but Y value is positive
     INY : INY : CPY #$0000 : BPL .normal_load_palette
 
-    ; Spacetime, sanity check that X is 0 (if not then do the original routine)
+    ; Sanity check that X is 0 (if not then do the original routine)
     CPX #$0000 : BNE .normal_load_palette
 
-    ; Spacetime, check if Y will cause us to reach WRAM
-    TYA : CLC : ADC #(!WRAM_START-$7EC1E2) : CMP #$0000 : BPL .normal_load_palette
+    ; Spacetime
+    LDA $00 : STA !ram_spacetime_read_address
+    LDA $02 : STA !ram_spacetime_read_bank
+    TYA : DEC : DEC : STA !ram_spacetime_y
+
+    ; Check if Y will cause us to reach infohud
+    CLC : ADC #($7EC608-$7EC1E0) : CMP #$0000 : BPL .normal_load_palette
 
     ; It will, so run our own loop
     INX : INX
+  .loop_before_infohud
+    LDA [$00],Y
+    STA $7EC1C0,X
+    INX : INX : INY : INY
+    CPX #($7EC608-$7EC1C0) : BMI .loop_before_infohud
+ 
+    ; Check if we should skip over infohud
+    LDA !ram_spacetime_infohud : BEQ .check_wram
+
+    ; Skip over infohud and check for wram
+    TXA : CLC : ADC #($7EC6C8-$7EC608) : TAX
+    TYA : CLC : ADC #($7EC6C8-$7EC608) : TAY
+    CPY #$0020 : BMI .check_wram
+    RTS
+
+  .normal_load_loop
+    LDA [$00],Y
+    STA $7EC1C0,X
+    INY : INY
+  .normal_load_palette
+    INX : INX
+    CPY #$0020 : BMI .normal_load_loop
+    RTS
+
+  .check_wram_overwrite_infohud
+    ; Check if Y will cause us to reach WRAM
+    TYA : CLC : ADC #(!WRAM_START-$7EC62A) : CMP #$0000 : BPL .normal_load_palette
+    BRA .loop_before_wram
+
+  .check_wram
+    ; Check if Y will cause us to reach WRAM
+    TYA : CLC : ADC #(!WRAM_START-$7EC6EA) : CMP #$0000 : BPL .normal_load_palette
+
+    ; It will, so run our own loop
   .loop_before_wram
     LDA [$00],Y
     STA $7EC1C0,X
@@ -521,15 +560,6 @@ spacetime_routine:
     ; Skip over WRAM and resume normal loop
     TXA : CLC : ADC !WRAM_SIZE : TAX
     TYA : CLC : ADC !WRAM_SIZE : TAY
-    CPY #$0020 : BMI .normal_load_loop
-    RTS
-
-  .normal_load_loop
-    LDA [$00],Y
-    STA $7EC1C0,X
-    INY : INY
-  .normal_load_palette
-    INX : INX
     CPY #$0020 : BMI .normal_load_loop
     RTS
 }

--- a/src/presets.asm
+++ b/src/presets.asm
@@ -105,6 +105,10 @@ endif
     LDA $7ED820 : BIT #$0004 : BEQ .done_clearing_enemies
     ; Set health to 1 as a hint this was done by a preset
     LDA #$0001 : STA $0FCC
+    ; Reset segment timer now
+    LDA #$0000 : STA !ram_reset_segment_later
+    STA !ram_seg_rt_frames : STA !ram_seg_rt_seconds
+    STA !ram_seg_rt_minutes
     BRA .done_clearing_enemies
 }
 

--- a/web/data/help.mdx
+++ b/web/data/help.mdx
@@ -115,6 +115,7 @@
 | - Samus Projectile Hitbox     | Toggles an overlay of Samus projectile hitboxes that are drawn on top of Samus projectile sprites.
 | - Enemy Projectile Hitbox     | Toggles an overlay of enemy projectile hitboxes that are drawn on top of enemy projectile sprites.
 | - OOB Tile Viewer             | This enables an overlay that shows the tiles near Samus at all times, disconnected from the camera. This allows you to navigate OOB (Out of Bounds) areas where neither Samus nor the actual tiles are visible in-game. Samus hitbox is drawn at the center of the overlay to show the position relative to the tiles.
+| - Spacetime HUD               | Option to preserve the infohud when firing the spacetime beam
 |&nbsp;|
 | **Room Layout**               | Modify the room layout, usually to help practice rando scenarios
 | - Remove Magnet Stairs        | Adds slope tiles to prevent the magnet stairs effect

--- a/web/data/infohudmode.mdx
+++ b/web/data/infohudmode.mdx
@@ -96,7 +96,12 @@ Last two characters = Feedback on the time when you jumped, with respect to spac
 - L# indicates you were late where the number tells you how many frames you were late.
 
 ## Quick Drop
-Displays the number of frames between pressing a left or right input and another left or right input, if the number of frames is between 1 and 20.
+Displays the number of frames between pressing a left or right input and another left or right input, if the number of frames is between 1 and 20. If a down input is pressed, then feedback on mid-air morph bomb spread will be given:
+&nbsp;  
+First two characters = Feedback on mid-air morph while beam is charged:
+- E# indicates you were early where the number tells you how many frames you were early.
+- YY indicates you attempted to morph on the correct frame.
+- L# indicates you were late where the number tells you how many frames you were late.
 
 ## Wall Jump
 Displays the number of frames between pressing a left or right input and pressing the jump button, if the number of frames is between 1 and 20. On NTSC, to walljump this number should be between 2 and 9 inclusive. Also, if the number of frames is 9 (required for a max-delayed walljump) and the walljump is taking place in WRITG, plasma room, or bubble mountain, then additional information may be presented if you appear to be making hi-jump bootless walljump attempts:


### PR DESCRIPTION
I pulled in cout's changes.  Also fixed some stuff mentioned in practice-hack channel:
- I busted elevator CF a few months back
- Segment timer resets at end of MB2/MB3 preset, I changed to reset on next event which is conveniently end of MB1 fight
- Added bomb spread to quick drop strat (I thought I did that already, not sure why I didn't, it was easy)

Thanks for finding my mistake with 41/43 variables, but I really did want to use 41/43 so when attempting to load C1/C3 in memory viewer so we can draw it... we can't use C1/C3 to load C1/C3!  Thus wanted to use 41/43 there.  Hopefully I got it right this time.

I need to review my infohud preservation during spacetime beam one more time.  I think it works but the math is tricky.  Also need to remember to add protection for xray.  Otherwise I think we are getting close to releasing 2.4.2.

Hey whatever happened to the infinite enemy fight logic?  Something like that might be useful for low ice training, I was thinking of an option to create a 400 or 800 low ice fight instead of the 200 shot fight.